### PR TITLE
fix: 404 Error

### DIFF
--- a/hey-sugar-tracker/netlify.toml
+++ b/hey-sugar-tracker/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200

--- a/hey-sugar-tracker/yarn.lock
+++ b/hey-sugar-tracker/yarn.lock
@@ -876,6 +876,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@hey-sugar/sanity-plugin-hey-sugar-schema@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@hey-sugar/sanity-plugin-hey-sugar-schema/-/sanity-plugin-hey-sugar-schema-0.3.0.tgz#c3a67aff11fa82faf614336874a3fe39b59f8a33"
+  integrity sha512-wFgzPgaAbS55C+vV5XqNNBUdqxLAqR3WdGIHLnCqYQmh7SJpQI5+GMhyUJtB408XBn9Xcshm2Ambxytb7/vsSw==
+  dependencies:
+    date-fns "^2.13.0"
+    react "^16.8.6"
+    react-icons "^3.7.0"
+
 "@hot-loader/react-dom@^16.9.0-4.12.11":
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.13.0.tgz#de245b42358110baf80aaf47a0592153d4047997"
@@ -7328,6 +7337,13 @@ react-icons@^3.10.0:
   dependencies:
     camelcase "^5.0.0"
 
+react-icons@^3.7.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.11.0.tgz#2ca2903dfab8268ca18ebd8cc2e879921ec3b254"
+  integrity sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-immutable-proptypes@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz#cce96d68cc3c18e89617cbf3092d08e35126af4a"
@@ -7482,6 +7498,15 @@ react@^16.2:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.8.6:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
The tracker will fire a 404 error without the redirect rules in place on Netlify. This fix introduces a `.toml` file to handle this. Big thanks to @sachinsancheti1 for fixing this in the Sanity template.